### PR TITLE
Fixed encoding bug

### DIFF
--- a/lib/flaggie/cache.py
+++ b/lib/flaggie/cache.py
@@ -14,7 +14,7 @@ from portage.versions import best
 def grab_use_desc(path, prefix=''):
 	flags = {}
 	try:
-		f = open(path, 'r')
+		f = open(path, 'r', encoding="utf-8")
 	except IOError:
 		pass
 	else:


### PR DESCRIPTION
Whenever I run flaggie through doas it would break resulting in:

```
$ doas flaggie vlc +libass
doas (raven@overlord) password:
Traceback (most recent call last):
  File "/usr/lib/python-exec/python3.6/flaggie", line 25, in <module>
    sys.exit(main(sys.argv))
  File "/usr/lib64/python3.6/site-packages/flaggie/cli.py", line 195, in main
    porttree, cache)
  File "/usr/lib64/python3.6/site-packages/flaggie/makeconf.py", line 549, in __init__
    flagcache)
  File "/usr/lib64/python3.6/site-packages/flaggie/makeconf.py", line 265, in add_expand
    values = [f for f in flagcache.glob if f.startswith(key)]
  File "/usr/lib64/python3.6/site-packages/flaggie/cache.py", line 81, in glob
    prefix = '%s_' % k.lower()))
  File "/usr/lib64/python3.6/site-packages/flaggie/cache.py", line 19, in grab_use_desc
    for l in f:
  File "/usr/lib64/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 664: ordinal not in range(128)
```

It would work fine when logged in as root.

Adding `encoding="utf-8"` fixed the issue, also looking at `Issues` there were similar problems with encoding.